### PR TITLE
Use yaml.safe_load instead of yaml.load without an explicit loader

### DIFF
--- a/docker_compose_wait.py
+++ b/docker_compose_wait.py
@@ -60,7 +60,7 @@ def get_docker_compose_args(args):
     return nargs
 
 def get_services_ids(dc_args):
-    services_names = yaml.load(call(["docker-compose"] + dc_args + ["config"]))["services"].keys()
+    services_names = yaml.safe_load(call(["docker-compose"] + dc_args + ["config"]))["services"].keys()
     services = {}
     for name in services_names:
         id = call(["docker-compose"] + dc_args + ["ps", '-q', name]).strip()


### PR DESCRIPTION
This eliminates the deprecation warning:
```
docker_compose_wait.py:63: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  services_names = yaml.load(call(["docker-compose"] + dc_args + ["config"]))["services"].keys()
```
safe_load is more backwards compatible than load with an explicit loader, at the cost of reduced functionality. But for the given usage, this additional functionality is unnecessary since no custom Python objects are involved. Therefore, changing load to safe_load is the best compromise between supporting users with older versions of pyyaml and eliminating the deprecation warning for users with newer versions of pyyaml, without the hassle of suppressing the warning with an environment variable.